### PR TITLE
Refactoring core types

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,28 @@ Create a nuget.config file in the root of your project:
     </configuration>   
 
 Alternately, you can setup nuget to get the package from the filesystem. The nupkg files are included in the repository in the <code>./library</code> folder.
+
+## Creating your own mailers
+
+To implement your own full-featured mailer, simply implement a class that implements <code>IStandardMailer&lt;TSettings&gt;</code>. 
+
+If you don't care about templates, you can create a simple mailer by just implementing <code>ISimpleMailer&lt;TSettings&gt;</code>.
+
+For the above interfaces, <code>TSettings</code> is a custom DTO class containing any configuration settings your mailer requires.
+
+The NullDesk mailers include both a simple and full-featured mailer; the full-featured mailers typically inherit the simple mailer as a base class, then extend it to add additional tempalate features from <code>IStandardMailer&lt;TSettings&gt;</code>. Here is an example of how that looks:
+
+    public class MyMailerSettings : IMailerSettings
+    {
+        //... implementation here
+    }
+
+    public class MySimpleMailer : ISimpleMailer<MyMailerSettings>
+    {
+        //... implementation here
+    }
+
+    public class MyFullMailer : MySimpleMailer, IStandardMailer<MyMailerSettings>
+    {
+        //... implementation here
+    }

--- a/samples/mailer-cli/mailer/Commands/SendSimpleMessage.cs
+++ b/samples/mailer-cli/mailer/Commands/SendSimpleMessage.cs
@@ -68,11 +68,11 @@ namespace Sample.Mailer.Cli.Commands
             }, false);
         }
 
-        private ITemplateMailer Mailer { get; }
+        private IStandardMailer Mailer { get; }
 
         private SimpleMessageSettings Settings{get;}
 
-        public SendSimpleMessage(AnsiConsole console, ITemplateMailer mailer, IOptions<TestMessageSettings> settings) : base(console)
+        public SendSimpleMessage(AnsiConsole console, IStandardMailer mailer, IOptions<TestMessageSettings> settings) : base(console)
         {
             Mailer = mailer;
             Settings = settings.Value.SimpleMessageSettings;

--- a/samples/mailer-cli/mailer/Commands/SendTemplateMessage.cs
+++ b/samples/mailer-cli/mailer/Commands/SendTemplateMessage.cs
@@ -70,11 +70,11 @@ namespace Sample.Mailer.Cli.Commands
             }, false);
         }
 
-        private ITemplateMailer Mailer { get; }
+        private IStandardMailer Mailer { get; }
 
         private TemplateMessageSettings Settings { get; }
 
-        public SendTemplateMessage(AnsiConsole console, ITemplateMailer mailer, IOptions<TestMessageSettings> settings) : base(console)
+        public SendTemplateMessage(AnsiConsole console, IStandardMailer mailer, IOptions<TestMessageSettings> settings) : base(console)
         {
             Mailer = mailer;
             if (mailer is SendGridMailer)

--- a/samples/mailer-cli/mailer/Startup.cs
+++ b/samples/mailer-cli/mailer/Startup.cs
@@ -56,7 +56,6 @@ namespace Sample.Mailer.Cli
             services.AddLogging();
           
             services.Configure<MkSmtpMailerSettings>(Config.GetSection("MailSettings:MkSmtpMailerSettings"));
-            services.Configure<FileTemplateMailerSettings>(Config.GetSection("MailSettings:FileTemplateMailerSettings"));
             services.Configure<SendGridMailerSettings>(Config.GetSection("MailSettings:SendGridMailerSettings"));
             
             services.Configure<TestMessageSettings>(Config.GetSection("TestMessageSettings"));
@@ -73,7 +72,7 @@ namespace Sample.Mailer.Cli
                 : typeof(MkSmtpMailer);
 
             //add the actual interface type we'll use when asking for a template mailer
-            services.AddTransient(s => (ITemplateMailer)s.GetService(templateMailerType));
+            services.AddTransient(s => (IStandardMailer)s.GetService(templateMailerType));
 
 
             services.AddSingleton(provider => AnsiConsole.GetOutput(true));

--- a/samples/mailer-cli/mailer/appsettings.json
+++ b/samples/mailer-cli/mailer/appsettings.json
@@ -14,18 +14,18 @@
       "FromDisplayName": "Sample Mailer CLI - MailKit",
       "SmtpServer": "localhost",
       "SmtpPort": 25,
-      "SmtpUseSsl": false
+      "SmtpUseSsl": false,
+      "TemplateSettings": {
+        "TemplatePath": "./App_Data/Templates",
+        "HtmlTemplateFileExtensions": [ "html" ],
+        "TextTemplateFileExtension": [ "txt" ]
+      } 
     },
     "SendGridMailerSettings": {
       "ApiKey": "your-api-key-here",
       "FromEmailAddress": "test@test.com",
       "FromDisplayName": "Sample Mailer CLI - SendGrid",
       "IsSandboxMode": true
-    },
-    "FileTemplateMailerSettings": {
-      "TemplatePath": "./App_Data/Templates",
-      "HtmlTemplateFileExtensions": ["html"],
-      "TextTemplateFileExtension": ["txt"]
     }
   },
   "TestMessageSettings": {

--- a/src/NullDesk.Extensions.Mailer.Core/IMailerTemplateSettings.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/IMailerTemplateSettings.cs
@@ -1,8 +1,0 @@
-﻿
-namespace NullDesk.Extensions.Mailer.Core
-{
-    /// <summary>
-    /// Mailer settings marker interface
-    /// </summary>
-    public interface IMailerTemplateSettings{}
-}

--- a/src/NullDesk.Extensions.Mailer.Core/ISimpleMailer.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/ISimpleMailer.cs
@@ -4,11 +4,24 @@ using System.Threading;
 using System.Threading.Tasks;
 namespace NullDesk.Extensions.Mailer.Core
 {
+    /// <summary>
+    /// Simplified mailer interface
+    /// </summary>
+    /// <typeparam name="TSettings">The type of the mailer settings.</typeparam>
+    /// <seealso cref="NullDesk.Extensions.Mailer.Core.ISimpleMailer" />
+    public interface ISimpleMailer<TSettings> : ISimpleMailer where TSettings : class, IMailerSettings
+    {
+        /// <summary>
+        /// Settings for the mailer service
+        /// </summary>
+        /// <returns></returns>
+        TSettings Settings { get; set; }
+    }
 
     /// <summary>
-    /// Common mailer interface
+    /// Simplified mailer
     /// </summary>
-    public interface IMailer
+    public interface ISimpleMailer
     {
         /// <summary>
         /// Send mail as an asynchronous operation.
@@ -69,15 +82,5 @@ namespace NullDesk.Extensions.Mailer.Core
             CancellationToken token);
     }
 
-    /// <summary>
-    /// Mailer with settings interface
-    /// </summary>
-    public interface IMailer<T> : IMailer where T : class, IMailerSettings
-    {
-        /// <summary>
-        /// Settings for the mailer service
-        /// </summary>
-        /// <returns></returns>
-        T Settings { get; set; }
-    }
+   
 }

--- a/src/NullDesk.Extensions.Mailer.Core/IStandardMailer.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/IStandardMailer.cs
@@ -6,9 +6,18 @@ using System.Threading.Tasks;
 namespace NullDesk.Extensions.Mailer.Core
 {
     /// <summary>
-    /// Common template mailer interface
+    /// Standard template mailer interface
     /// </summary>
-    public interface ITemplateMailer: IMailer
+    /// <typeparam name="TSettings">The type of the mailer settings.</typeparam>
+    /// <seealso cref="NullDesk.Extensions.Mailer.Core.IStandardMailer" />
+    /// <seealso cref="NullDesk.Extensions.Mailer.Core.ISimpleMailer{TSettings}" />
+    public interface IStandardMailer<TSettings> : IStandardMailer, ISimpleMailer<TSettings>  where TSettings : class, IMailerSettings { }
+
+    /// <summary>
+    /// Standard template mailer interface
+    /// </summary>
+    /// <seealso cref="NullDesk.Extensions.Mailer.Core.ISimpleMailer" />
+    public interface IStandardMailer : ISimpleMailer
     {
         /// <summary>
         /// Send mail using a template.
@@ -77,15 +86,5 @@ namespace NullDesk.Extensions.Mailer.Core
 
     }
 
-    /// <summary>
-    /// Template Mailer with settings interface
-    /// </summary>
-    public interface ITemplateMailer<T>: ITemplateMailer where T : class, IMailerTemplateSettings
-    {
-        /// <summary>
-        /// Template settings 
-        /// </summary>
-        /// <returns></returns>
-        T TemplateSettings { get; set; }
-    }
+    
 }

--- a/src/NullDesk.Extensions.Mailer.Core/MailerFactory.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/MailerFactory.cs
@@ -10,13 +10,17 @@ namespace NullDesk.Extensions.Mailer.Core
     /// </summary>
     public class MailerFactory
     {
-        private List<Func<IMailer>> Mailers { get; } = new List<Func<IMailer>>();
+        /// <summary>
+        /// Gets a collection of registered mailer functions.
+        /// </summary>
+        /// <value>The mailers.</value>
+        public List<Func<ISimpleMailer>> Mailers { get; } = new List<Func<ISimpleMailer>>();
 
         /// <summary>
         /// Gets an instance of the first registered standard mailer.
         /// </summary>
         /// <value>The mailer.</value>
-        public ITemplateMailer Mailer
+        public virtual IStandardMailer Mailer
         {
             get
             {
@@ -25,8 +29,8 @@ namespace NullDesk.Extensions.Mailer.Core
                     .GenericTypeArguments
                     .FirstOrDefault()?
                     .GetTypeInfo()
-                    .ImplementedInterfaces.Any(i => i == typeof(ITemplateMailer)) ?? false);
-                return func?.Invoke() as ITemplateMailer;
+                    .ImplementedInterfaces.Any(i => i == typeof(IStandardMailer)) ?? false);
+                return func?.Invoke() as IStandardMailer;
             }
         }
 
@@ -34,7 +38,7 @@ namespace NullDesk.Extensions.Mailer.Core
         /// Gets an instance of the first registered simple mailer.
         /// </summary>
         /// <value>The simple mailer.</value>
-        public IMailer SimpleMailer
+        public virtual ISimpleMailer SimpleMailer
         {
             get
             {
@@ -43,7 +47,7 @@ namespace NullDesk.Extensions.Mailer.Core
                             .GenericTypeArguments
                             .FirstOrDefault()?
                             .GetTypeInfo()
-                            .ImplementedInterfaces.All(i => i != typeof(ITemplateMailer)) ??
+                            .ImplementedInterfaces.All(i => i != typeof(IStandardMailer)) ??
                         false);
                 // template mailers also implement IMailer, and can act as a surrogate if a simple mailer wasn't explicitly registered.
                 //if simple mailer isn't registered, return a template mailer if one is registered.
@@ -57,7 +61,7 @@ namespace NullDesk.Extensions.Mailer.Core
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="mailerFunc">The mailer function.</param>
-        public void Register<T>(Func<T> mailerFunc) where T : class, IMailer
+        public virtual void Register<T>(Func<T> mailerFunc) where T : class, ISimpleMailer
         {
             Mailers.Add(mailerFunc);
         }
@@ -70,7 +74,7 @@ namespace NullDesk.Extensions.Mailer.Core
         /// </remarks>
         /// <typeparam name="T">The type of mailer instance you wish to create</typeparam>
         /// <returns>T.</returns>
-        public T GetMailer<T>() where T : class, IMailer
+        public virtual T GetMailer<T>() where T : class, ISimpleMailer
         {
             var mailer = Mailers.FirstOrDefault(m => m.GetType().GenericTypeArguments.FirstOrDefault()?.AssemblyQualifiedName == typeof(T).AssemblyQualifiedName);
             return mailer?.Invoke() as T;

--- a/src/NullDesk.Extensions.Mailer.MailKit/MailerFactoryExtensions.cs
+++ b/src/NullDesk.Extensions.Mailer.MailKit/MailerFactoryExtensions.cs
@@ -53,18 +53,15 @@ namespace NullDesk.Extensions.Mailer.MailKit
         /// </summary>
         /// <param name="factory">The factory.</param>
         /// <param name="mailerSettings">The mailer settings.</param>
-        /// <param name="templateSettings">The template settings.</param>
         /// <param name="logger">The logger.</param>
         public static void AddMkSmtpMailer(
             this MailerFactory factory,
             MkSmtpMailerSettings mailerSettings,
-            FileTemplateMailerSettings templateSettings,
             ILogger<MkSmtpMailer> logger = null)
         {
             factory.Register(() =>
                 new MkSmtpMailer(
                     new OptionsWrapper<MkSmtpMailerSettings>(mailerSettings),
-                    new OptionsWrapper<FileTemplateMailerSettings>(templateSettings),
                     logger));
         }
 
@@ -74,20 +71,17 @@ namespace NullDesk.Extensions.Mailer.MailKit
         /// <param name="factory">The factory.</param>
         /// <param name="client">The SMTP client.</param>
         /// <param name="mailerSettings">The mailer settings.</param>
-        /// <param name="templateSettings">The template settings.</param>
         /// <param name="logger">The logger.</param>
         public static void AddMkSmtpMailer(
             this MailerFactory factory,
             SmtpClient client,
             MkSmtpMailerSettings mailerSettings,
-            FileTemplateMailerSettings templateSettings,
             ILogger<MkSmtpMailer> logger = null)
         {
             factory.Register(() =>
                 new MkSmtpMailer(
                     client,
                     new OptionsWrapper<MkSmtpMailerSettings>(mailerSettings),
-                    new OptionsWrapper<FileTemplateMailerSettings>(templateSettings),
                     logger));
 
         }

--- a/src/NullDesk.Extensions.Mailer.MailKit/MkFileTemplateSettings.cs
+++ b/src/NullDesk.Extensions.Mailer.MailKit/MkFileTemplateSettings.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 
-namespace NullDesk.Extensions.Mailer.Core
+namespace NullDesk.Extensions.Mailer.MailKit
 {
     /// <summary>
-    /// Settings for SMTP Email Services.
+    /// File template settings for MailKit mailers.
     /// </summary>
-    public class FileTemplateMailerSettings : IMailerTemplateSettings
+    public class MkFileTemplateSettings
     {
-
         /// <summary>
         /// The folder path where templates are stored.
         /// </summary>
@@ -18,13 +17,12 @@ namespace NullDesk.Extensions.Mailer.Core
         /// Collection of possible HTML template file name extensions
         /// </summary>
         /// <value>The HTML template file extensions.</value>
-        public IEnumerable<string> HtmlTemplateFileExtensions { get; set; } = new [] {"htm", "html"};
+        public IEnumerable<string> HtmlTemplateFileExtensions { get; set; } = new[] { "htm", "html" };
 
         /// <summary>
         /// Gets or sets the text template file extension.
         /// </summary>
         /// <value>The text template file extension.</value>
-        public IEnumerable<string> TextTemplateFileExtension { get; set; } = new [] {"txt"};
-
+        public IEnumerable<string> TextTemplateFileExtension { get; set; } = new[] { "txt" };
     }
 }

--- a/src/NullDesk.Extensions.Mailer.MailKit/MkSmtpAuthenticationSettings.cs
+++ b/src/NullDesk.Extensions.Mailer.MailKit/MkSmtpAuthenticationSettings.cs
@@ -1,0 +1,29 @@
+﻿namespace NullDesk.Extensions.Mailer.MailKit
+{
+    /// <summary>
+    /// Authentication for MailKit SMTP mailers.
+    /// </summary>
+    public class MkSmtpAuthenticationSettings
+    {
+        /// <summary>
+        /// If provided, specifies the username used to authenticate with the SMTP server 
+        /// </summary>
+        /// <returns>The username</returns>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// If provided, specifies the password used to authenticate with the SMTP server 
+        /// </summary>
+        /// <returns></returns>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// If provided, specifies the credentials used to autheticate with the SMTP server.
+        /// </summary>
+        /// <remarks>
+        /// Will be used instead of username and password if provided.
+        /// </remarks>
+        /// <returns></returns>
+        public System.Net.ICredentials Credentials { get; set; }
+    }
+}

--- a/src/NullDesk.Extensions.Mailer.MailKit/MkSmtpMailerSettings.cs
+++ b/src/NullDesk.Extensions.Mailer.MailKit/MkSmtpMailerSettings.cs
@@ -9,24 +9,15 @@ namespace NullDesk.Extensions.Mailer.MailKit
     public class MkSmtpMailerSettings: SmtpMailerSettings
     {
         /// <summary>
-        /// If provided, specifies the username used to authenticate with the SMTP server 
+        /// Gets or sets the template settings.
         /// </summary>
-        /// <returns>The username</returns>
-        public string UserName { get; set; }
+        /// <value>The template settings.</value>
+        public MkFileTemplateSettings TemplateSettings { get; set; }
 
         /// <summary>
-        /// If provided, specifies the password used to authenticate with the SMTP server 
+        /// Gets or sets the authentication settings.
         /// </summary>
-        /// <returns></returns>
-        public string Password { get; set; }
-
-        /// <summary>
-        /// If provided, specifies the credentials used to autheticate with the SMTP server.
-        /// </summary>
-        /// <remarks>
-        /// Will be used instead of username and password if provided.
-        /// </remarks>
-        /// <returns></returns>
-        public System.Net.ICredentials Credentials { get; set; }
+        /// <value>The authentication settings.</value>
+        public MkSmtpAuthenticationSettings AuthenticationSettings { get; set; }
     }
 }

--- a/src/NullDesk.Extensions.Mailer.SendGrid/SendGridMailer.cs
+++ b/src/NullDesk.Extensions.Mailer.SendGrid/SendGridMailer.cs
@@ -14,7 +14,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid
     /// <summary>
     /// Standard message and template mail service using SendGrid.
     /// </summary>
-    public class SendGridMailer : SendGridSimpleMailer, ITemplateMailer
+    public class SendGridMailer : SendGridSimpleMailer, IStandardMailer<SendGridMailerSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SendGridMailer" /> class.
@@ -54,7 +54,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid
         /// <param name="replacementVariables">The replacement variables. The key should include the delimiters needed to locate text which should be replaced.</param>
         /// <param name="token">The cancellation token.</param>
         /// <returns>Task&lt;System.Boolean&gt;.</returns>
-        public async Task<bool> SendMailAsync(
+        public virtual async Task<bool> SendMailAsync(
             string template,
             string toEmailAddress,
             string toDisplayName,

--- a/src/NullDesk.Extensions.Mailer.SendGrid/SendGridSimpleMailer.cs
+++ b/src/NullDesk.Extensions.Mailer.SendGrid/SendGridSimpleMailer.cs
@@ -16,7 +16,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid
     /// <summary>
     /// Simplified email service for SendGrid. 
     /// </summary>
-    public class SendGridSimpleMailer : IMailer<SendGridMailerSettings>
+    public class SendGridSimpleMailer : ISimpleMailer<SendGridMailerSettings>
     {
 
         /// <summary>
@@ -47,7 +47,10 @@ namespace NullDesk.Extensions.Mailer.SendGrid
         /// <param name="client">The SendGrid client instance</param>
         /// <param name="settings">The settings.</param>
         /// <param name="logger">Optional ILogger instance.</param>
-        public SendGridSimpleMailer(Client client, IOptions<SendGridMailerSettings> settings, ILogger<SendGridSimpleMailer> logger = null)
+        public SendGridSimpleMailer(
+            Client client, 
+            IOptions<SendGridMailerSettings> settings, 
+            ILogger<SendGridSimpleMailer> logger = null)
         {
             Settings = settings.Value;
             MailClient = client;
@@ -59,8 +62,10 @@ namespace NullDesk.Extensions.Mailer.SendGrid
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <param name="logger">Optional ILogger instance.</param>
-        public SendGridSimpleMailer(IOptions<SendGridMailerSettings> settings, ILogger<SendGridSimpleMailer> logger = null)
-            : this(new Client(settings.Value.ApiKey), settings, logger) { }
+        public SendGridSimpleMailer(
+            IOptions<SendGridMailerSettings> settings, 
+            ILogger<SendGridSimpleMailer> logger = null)
+        : this(new Client(settings.Value.ApiKey), settings, logger) { }
 
         /// <summary>
         /// Send mail as an asynchronous operation.
@@ -211,7 +216,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid
         /// <param name="token">The token.</param>
         /// <returns>Task&lt;System.String&gt;.</returns>
         /// <remarks>Will read and dispose the stream</remarks>
-        protected async Task<string> StreamToBase64Async(Stream input, CancellationToken token)
+        protected virtual async Task<string> StreamToBase64Async(Stream input, CancellationToken token)
         {
             MemoryStream ms;
             if (input is MemoryStream)

--- a/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/FactoryMailFixture.cs
+++ b/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/FactoryMailFixture.cs
@@ -26,10 +26,7 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests.Infrastructure
             var logger = loggerFactory.CreateLogger<MkSmtpMailer>();
             var simpleLogger = loggerFactory.CreateLogger<MkSimpleSmtpMailer>();
 
-            var mkTemplateSettings = new FileTemplateMailerSettings
-            {
-                TemplatePath = "../TestData/templates"
-            };
+           
 
             var isMailServerAlive = false;
             var mkSettings = SetupMailerOptions(out isMailServerAlive).Value;
@@ -40,18 +37,18 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests.Infrastructure
                 .Returns(Task.CompletedTask);
             if (isMailServerAlive)
             {
-                Mail.AddMkSmtpMailer(mkSettings, mkTemplateSettings, logger);
+                Mail.AddMkSmtpMailer(mkSettings, logger);
                 Mail.AddMkSimpleSmtpMailer(mkSettings, simpleLogger);
 
-                TemplateMail.AddMkSmtpMailer(mkSettings, mkTemplateSettings, logger);
+                TemplateMail.AddMkSmtpMailer(mkSettings, logger);
 
             }
             else
             {
-                Mail.AddMkSmtpMailer(client, mkSettings, mkTemplateSettings, logger);
+                Mail.AddMkSmtpMailer(client, mkSettings, logger);
                 Mail.AddMkSimpleSmtpMailer(client, mkSettings, simpleLogger);
 
-                TemplateMail.AddMkSmtpMailer(client, mkSettings, mkTemplateSettings, logger);
+                TemplateMail.AddMkSmtpMailer(client, mkSettings, logger);
 
             }
         }

--- a/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/MailFixture.cs
+++ b/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/MailFixture.cs
@@ -15,7 +15,11 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests.Infrastructure
                     FromDisplayName = "Xunit",
                     SmtpServer = "localhost",
                     SmtpPort = 25,
-                    SmtpUseSsl = false
+                    SmtpUseSsl = false,
+                    TemplateSettings = new MkFileTemplateSettings()
+                    {
+                        TemplatePath = "../TestData/templates"
+                    }
                 });
 
             isMailServerAlive = false;

--- a/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/StandardMailFixture.cs
+++ b/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/StandardMailFixture.cs
@@ -24,7 +24,7 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests.Infrastructure
 
             var isMailServerAlive = false;
             var lazy = new Lazy<OptionsWrapper<MkSmtpMailerSettings>>(() => SetupMailerOptions(out isMailServerAlive));
-            services.AddTransient<IMailer>(s =>
+            services.AddTransient<ISimpleMailer>(s =>
             {
                 var options = lazy.Value;
                 var client = Substitute.For<SmtpClient>();

--- a/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/TemplateMailFixture.cs
+++ b/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/TemplateMailFixture.cs
@@ -23,16 +23,10 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests.Infrastructure
 
             services.AddOptions();
 
-            var templateOptions = new OptionsWrapper<FileTemplateMailerSettings>(
-                new FileTemplateMailerSettings
-                {
-                    TemplatePath = "../TestData/templates"
-                });
-
             var isMailServerAlive = false;
             var lazy = new Lazy<OptionsWrapper<MkSmtpMailerSettings>>(() => SetupMailerOptions(out isMailServerAlive));
 
-            services.AddTransient<ITemplateMailer>(s =>
+            services.AddTransient<IStandardMailer>(s =>
             {
                 var options = lazy.Value;
                 var client = Substitute.For<SmtpClient>();
@@ -40,8 +34,8 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests.Infrastructure
                     .SendAsync(Arg.Any<MimeMessage>(), Arg.Any<CancellationToken>())
                     .Returns(Task.CompletedTask);
                 return (isMailServerAlive)
-                    ? new MkSmtpMailer(options, templateOptions, s.GetService<ILogger<MkSmtpMailer>>())
-                    : new MkSmtpMailer(client, options, templateOptions, s.GetService<ILogger<MkSmtpMailer>>());
+                    ? new MkSmtpMailer(options, s.GetService<ILogger<MkSmtpMailer>>())
+                    : new MkSmtpMailer(client, options, s.GetService<ILogger<MkSmtpMailer>>());
             });
 
 

--- a/test/NullDesk.Extensions.Mailer.MailKit.Tests/MailKitSmtpFileTemplateMailerTests.cs
+++ b/test/NullDesk.Extensions.Mailer.MailKit.Tests/MailKitSmtpFileTemplateMailerTests.cs
@@ -29,7 +29,7 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests
         public async Task SendMailWithTemplate(string template, string[] attachments)
         {
 
-            var mailer = Fixture.ServiceProvider.GetService<ITemplateMailer>();
+            var mailer = Fixture.ServiceProvider.GetService<IStandardMailer>();
 
             var result =
                 await

--- a/test/NullDesk.Extensions.Mailer.MailKit.Tests/MailKitSmtpMailerTests.cs
+++ b/test/NullDesk.Extensions.Mailer.MailKit.Tests/MailKitSmtpMailerTests.cs
@@ -23,7 +23,7 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests
         [ClassData(typeof(StandardMailerTestData))]
         public async Task SendMail(string html, string text, string[] attachments)
         {
-            var mailer = Fixture.ServiceProvider.GetService<IMailer>();
+            var mailer = Fixture.ServiceProvider.GetService<ISimpleMailer>();
             var result =
                 await
                     mailer.SendMailAsync(

--- a/test/NullDesk.Extensions.Mailer.SendGrid.Tests/Infrastructure/StandardMailFixture.cs
+++ b/test/NullDesk.Extensions.Mailer.SendGrid.Tests/Infrastructure/StandardMailFixture.cs
@@ -21,7 +21,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid.Tests.Infrastructure
             services.Configure<SendGridMailerSettings>(s => s.ApiKey = "abc");
             services.AddTransient<Client>(s => new FakeClient("abc"));
             services.AddTransient<SendGridSimpleMailer>();
-            services.AddTransient<IMailer>(s => s.GetService<SendGridSimpleMailer>());
+            services.AddTransient<ISimpleMailer>(s => s.GetService<SendGridSimpleMailer>());
 
 
             ServiceProvider = services.BuildServiceProvider();

--- a/test/NullDesk.Extensions.Mailer.SendGrid.Tests/Infrastructure/TemplateMailFixture.cs
+++ b/test/NullDesk.Extensions.Mailer.SendGrid.Tests/Infrastructure/TemplateMailFixture.cs
@@ -23,7 +23,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid.Tests.Infrastructure
             services.Configure<SendGridMailerSettings>(s => s.ApiKey = "abc");
             services.AddTransient<Client>(s => new FakeClient("abc"));
             services.AddTransient<SendGridMailer>();
-            services.AddTransient<ITemplateMailer>(s => s.GetService<SendGridMailer>());
+            services.AddTransient<IStandardMailer>(s => s.GetService<SendGridMailer>());
 
 
             ServiceProvider = services.BuildServiceProvider();

--- a/test/NullDesk.Extensions.Mailer.SendGrid.Tests/SendGridMailerTests.cs
+++ b/test/NullDesk.Extensions.Mailer.SendGrid.Tests/SendGridMailerTests.cs
@@ -25,7 +25,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid.Tests
         public async Task SendMail(string html, string text, string[] attachments)
         {
 
-            var mailer = Fixture.ServiceProvider.GetService<IMailer>();
+            var mailer = Fixture.ServiceProvider.GetService<ISimpleMailer>();
 
             var result =
                 await

--- a/test/NullDesk.Extensions.Mailer.SendGrid.Tests/SendGridTemplateMailerTests.cs
+++ b/test/NullDesk.Extensions.Mailer.SendGrid.Tests/SendGridTemplateMailerTests.cs
@@ -29,7 +29,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid.Tests
         public async Task SendMailWithTemplate(string template, string[] attachments)
         {
 
-            var mailer = Fixture.ServiceProvider.GetService<ITemplateMailer>();
+            var mailer = Fixture.ServiceProvider.GetService<IStandardMailer>();
 
             var result =
                 await


### PR DESCRIPTION
closes #16

- clarified interface names
- cleaned up the inheritance hierarchy between simple and template mailer interfaces
- got rid of template settings as a separate type
- added information on creating mailers to readme