### PR TITLE
Reusable mailers

### DIFF
--- a/src/NullDesk.Extensions.Mailer.Core/AsyncLock.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/AsyncLock.cs
@@ -1,0 +1,64 @@
+﻿// Based on code from Stephen Toub
+//   https://blogs.msdn.microsoft.com/pfxteam/2012/02/12/building-async-coordination-primitives-part-5-asyncsemaphore/
+//   https://blogs.msdn.microsoft.com/pfxteam/2012/02/12/building-async-coordination-primitives-part-6-asynclock/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NullDesk.Extensions.Mailer.Core
+{
+    /// <summary>
+    /// AsyncLock.
+    /// </summary>
+    public class AsyncLock
+    {
+        private readonly AsyncSemaphore _mSemaphore;
+        private readonly Task<Releaser> _mReleaser;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncLock"/> class.
+        /// </summary>
+        public AsyncLock()
+        {
+            _mSemaphore = new AsyncSemaphore(1);
+            _mReleaser = Task.FromResult(new Releaser(this));
+        }
+
+        /// <summary>
+        /// Create an async lock.
+        /// </summary>
+        /// <returns>Task&lt;Releaser&gt;.</returns>
+        public Task<Releaser> LockAsync()
+        {
+            var wait = _mSemaphore.WaitAsync();
+            return wait.IsCompleted
+                ? _mReleaser
+                : wait.ContinueWith((_, state) => new Releaser((AsyncLock) state),
+                    this, CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+
+        /// <summary>
+        /// Struct Releaser
+        /// </summary>
+        /// <seealso cref="System.IDisposable" />
+        public struct Releaser : IDisposable
+        {
+            private readonly AsyncLock _mToRelease;
+
+            internal Releaser(AsyncLock toRelease)
+            {
+                _mToRelease = toRelease;
+            }
+
+            /// <summary>
+            /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+            /// </summary>
+            public void Dispose()
+            {
+                _mToRelease?._mSemaphore.Release();
+            }
+        }
+    }
+}

--- a/src/NullDesk.Extensions.Mailer.Core/AsyncSemaphore.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/AsyncSemaphore.cs
@@ -1,0 +1,74 @@
+﻿// Based on code from Stephen Toub
+//   https://blogs.msdn.microsoft.com/pfxteam/2012/02/12/building-async-coordination-primitives-part-5-asyncsemaphore/
+//   https://blogs.msdn.microsoft.com/pfxteam/2012/02/12/building-async-coordination-primitives-part-6-asynclock/
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NullDesk.Extensions.Mailer.Core
+{
+    /// <summary>
+    /// Class AsyncSemaphore.
+    /// </summary>
+    public class AsyncSemaphore
+    {
+        private static readonly Task SCompleted = Task.FromResult(true);
+        private readonly Queue<TaskCompletionSource<bool>> _mWaiters = new Queue<TaskCompletionSource<bool>>();
+        private int _mCurrentCount;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncSemaphore"/> class.
+        /// </summary>
+        /// <param name="initialCount">The initial count.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">initialCount</exception>
+        public AsyncSemaphore(int initialCount)
+        {
+            if (initialCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(initialCount));
+            }
+            _mCurrentCount = initialCount;
+        }
+
+        /// <summary>
+        /// Async wait.
+        /// </summary>
+        /// <returns>Task.</returns>
+        public Task WaitAsync()
+        {
+            lock (_mWaiters)
+            {
+                if (_mCurrentCount > 0)
+                {
+                    --_mCurrentCount;
+                    return SCompleted;
+                }
+                var waiter = new TaskCompletionSource<bool>();
+                _mWaiters.Enqueue(waiter);
+                return waiter.Task;
+            }
+        }
+
+        /// <summary>
+        /// Releases this instance.
+        /// </summary>
+        public void Release()
+        {
+            TaskCompletionSource<bool> toRelease = null;
+            lock (_mWaiters)
+            {
+                if (_mWaiters.Count > 0)
+                {
+                    toRelease = _mWaiters.Dequeue();
+                }
+                else
+                {
+                    ++_mCurrentCount;
+                }
+            }
+            toRelease?.SetResult(true);
+        }
+    }
+}

--- a/src/NullDesk.Extensions.Mailer.Core/IMailerFactory.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/IMailerFactory.cs
@@ -13,7 +13,7 @@ namespace NullDesk.Extensions.Mailer.Core
         /// Gets a collection of registered mailer functions.
         /// </summary>
         /// <value>The mailers.</value>
-        List<Func<ISimpleMailer>> Mailers { get; }
+        List<Func<ISimpleMailer>> MailerRegistrations { get; }
 
         /// <summary>
         /// Gets an instance of the first registered standard mailer.

--- a/src/NullDesk.Extensions.Mailer.Core/MailerFactory.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/MailerFactory.cs
@@ -14,7 +14,7 @@ namespace NullDesk.Extensions.Mailer.Core
         /// Gets a collection of registered mailer functions.
         /// </summary>
         /// <value>The mailers.</value>
-        public List<Func<ISimpleMailer>> Mailers { get; } = new List<Func<ISimpleMailer>>();
+        public List<Func<ISimpleMailer>> MailerRegistrations { get; } = new List<Func<ISimpleMailer>>();
 
         /// <summary>
         /// Gets an instance of the first registered standard mailer.
@@ -24,7 +24,7 @@ namespace NullDesk.Extensions.Mailer.Core
         {
             get
             {
-                var func = Mailers.FirstOrDefault(m => m
+                var func = MailerRegistrations.FirstOrDefault(m => m
                     .GetType().GetTypeInfo()
                     .GenericTypeArguments
                     .FirstOrDefault()?
@@ -42,7 +42,7 @@ namespace NullDesk.Extensions.Mailer.Core
         {
             get
             {
-                var func = Mailers.FirstOrDefault(m => m
+                var func = MailerRegistrations.FirstOrDefault(m => m
                             .GetType().GetTypeInfo()
                             .GenericTypeArguments
                             .FirstOrDefault()?
@@ -51,7 +51,7 @@ namespace NullDesk.Extensions.Mailer.Core
                         false);
                 // template mailers also implement IMailer, and can act as a surrogate if a simple mailer wasn't explicitly registered.
                 //if simple mailer isn't registered, return a template mailer if one is registered.
-                var simple = func?.Invoke() ?? Mailers.FirstOrDefault()?.Invoke();
+                var simple = func?.Invoke() ?? MailerRegistrations.FirstOrDefault()?.Invoke();
                 return simple;
             }
         }
@@ -63,7 +63,7 @@ namespace NullDesk.Extensions.Mailer.Core
         /// <param name="mailerFunc">The mailer function.</param>
         public virtual void Register<T>(Func<T> mailerFunc) where T : class, ISimpleMailer
         {
-            Mailers.Add(mailerFunc);
+            MailerRegistrations.Add(mailerFunc);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace NullDesk.Extensions.Mailer.Core
         /// <returns>T.</returns>
         public virtual T GetMailer<T>() where T : class, ISimpleMailer
         {
-            var mailer = Mailers.FirstOrDefault(m => m.GetType().GenericTypeArguments.FirstOrDefault()?.AssemblyQualifiedName == typeof(T).AssemblyQualifiedName);
+            var mailer = MailerRegistrations.FirstOrDefault(m => m.GetType().GenericTypeArguments.FirstOrDefault()?.AssemblyQualifiedName == typeof(T).AssemblyQualifiedName);
             return mailer?.Invoke() as T;
         }
 

--- a/src/NullDesk.Extensions.Mailer.Core/NullDesk.Extensions.Mailer.Core.csproj
+++ b/src/NullDesk.Extensions.Mailer.Core/NullDesk.Extensions.Mailer.Core.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extensions base classes and abstractions for email messaging services</Description>
-    <VersionPrefix>2.2.2</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer.csproj
+++ b/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extension for SQL Server email messsage and delivery history storage using EntityFramework Core</Description>
-    <VersionPrefix>2.2.2</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/NullDesk.Extensions.Mailer.History.EntityFramework/NullDesk.Extensions.Mailer.History.EntityFramework.csproj
+++ b/src/NullDesk.Extensions.Mailer.History.EntityFramework/NullDesk.Extensions.Mailer.History.EntityFramework.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extensions base implementation of messsage and delivery history storage with EntityFramework Core.</Description>
-    <VersionPrefix>2.2.2</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/NullDesk.Extensions.Mailer.MailKit/NullDesk.Extensions.Mailer.MailKit.csproj
+++ b/src/NullDesk.Extensions.Mailer.MailKit/NullDesk.Extensions.Mailer.MailKit.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extensions for SMTP Email messaging using MailKit</Description>
     <VersionPrefix>2.3.0</VersionPrefix>
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="MailKit" Version="1.10.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NullDesk.Extensions.Mailer.Core\NullDesk.Extensions.Mailer.Core.csproj" />

--- a/src/NullDesk.Extensions.Mailer.MailKit/NullDesk.Extensions.Mailer.MailKit.csproj
+++ b/src/NullDesk.Extensions.Mailer.MailKit/NullDesk.Extensions.Mailer.MailKit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extensions for SMTP Email messaging using MailKit</Description>
-    <VersionPrefix>2.2.2</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/NullDesk.Extensions.Mailer.SendGrid/NullDesk.Extensions.Mailer.SendGrid.csproj
+++ b/src/NullDesk.Extensions.Mailer.SendGrid/NullDesk.Extensions.Mailer.SendGrid.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extensions for Email messaging using SendGrid API services</Description>
-    <VersionPrefix>2.2.2</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/NullDesk.Extensions.Mailer.SendGrid/SendGridSimpleMailer.cs
+++ b/src/NullDesk.Extensions.Mailer.SendGrid/SendGridSimpleMailer.cs
@@ -300,9 +300,9 @@ namespace NullDesk.Extensions.Mailer.SendGrid
         protected virtual async Task<string> StreamToBase64Async(Stream input, CancellationToken token = default(CancellationToken))
         {
             MemoryStream ms;
-            if (input is MemoryStream)
+            if (input is MemoryStream stream)
             {
-                ms = (MemoryStream)input;
+                ms = stream;
             }
             else
             {

--- a/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/ReusableMailFixture.cs
+++ b/test/NullDesk.Extensions.Mailer.MailKit.Tests/Infrastructure/ReusableMailFixture.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Smtp;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using NSubstitute;
+using NullDesk.Extensions.Mailer.Core;
+
+namespace NullDesk.Extensions.Mailer.MailKit.Tests.Infrastructure
+{
+    public class ReusableMailFixture : MailFixture, IDisposable
+    {
+        public IServiceProvider ServiceProvider { get; set; }
+
+        public ReusableMailFixture()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            
+            services.AddOptions();
+           
+            services.AddSingleton<IHistoryStore, InMemoryHistoryStore>();
+
+            var isMailServerAlive = false;
+            var lazy = new Lazy<OptionsWrapper<MkSmtpMailerSettings>>(() => SetupMailerOptions(out isMailServerAlive));
+            services.AddSingleton<ISimpleMailer>(s =>
+            {
+                var options = lazy.Value;
+                var client = Substitute.For<SmtpClient>();
+                client
+                  .SendAsync(Arg.Any<MimeMessage>(), Arg.Any<CancellationToken>())
+                  .Returns(Task.CompletedTask);
+                return (isMailServerAlive)
+                    ? new MkSimpleSmtpMailer(options, s.GetService<ILogger<MkSimpleSmtpMailer>>(), s.GetService<IHistoryStore>() )
+                    : new MkSimpleSmtpMailer(client, options, s.GetService<ILogger<MkSimpleSmtpMailer>>(), s.GetService<IHistoryStore>());
+            });
+            
+            ServiceProvider = services.BuildServiceProvider();
+            
+            var logging = ServiceProvider.GetService<ILoggerFactory>();
+            logging.AddDebug(LogLevel.Debug);
+            
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/test/NullDesk.Extensions.Mailer.MailKit.Tests/MailKitSmtpParallelMailerTests.cs
+++ b/test/NullDesk.Extensions.Mailer.MailKit.Tests/MailKitSmtpParallelMailerTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using NullDesk.Extensions.Mailer.Core;
+using NullDesk.Extensions.Mailer.MailKit.Tests.Infrastructure;
+using NullDesk.Extensions.Mailer.Tests.Common;
+
+namespace NullDesk.Extensions.Mailer.MailKit.Tests
+{
+    public class MailKitSmtpParallelMailerTests : IClassFixture<ReusableMailFixture>
+    {
+        private ReusableMailFixture Fixture { get; }
+
+        public MailKitSmtpParallelMailerTests(ReusableMailFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        [Theory]
+        [Trait("TestType", "Integration")]
+        [ClassData(typeof(StandardMailerTestData))]
+        public void SendParallelMail(string html, string text, string[] attachments)
+        {
+            var mailer = Fixture.ServiceProvider.GetService<ISimpleMailer>();
+            var messages = new List<TestParallelMailMessage>();
+            for (var i = 0; i < 10; i++)
+            {
+                messages.Add(new TestParallelMailMessage
+                {
+                    To = $"noone{i}@toast.com",
+                    ToDisplay = "No One Important",
+                    Subject = $"#{i} - Parallel xunit Test run: no template",
+                    Html = html,
+                    Text = text
+                });
+            }
+            Parallel.ForEach(messages, (mes) =>
+            {
+                var result =
+                        mailer.SendMailAsync(
+                            mes.To,
+                            mes.ToDisplay,
+                            mes.Subject,
+                            mes.Html,
+                            mes.Text,
+                            (IEnumerable<string>)null,
+                            CancellationToken.None
+                        ).Result;
+                result.Should().BeOfType<MessageDeliveryItem>().Which.IsSuccess.Should().BeTrue();
+                var m = result.Should().NotBeNull().And.BeOfType<MessageDeliveryItem>().Which;
+                m.IsSuccess.Should().BeTrue();
+                m.MessageData.Should().NotBeNullOrEmpty();
+            });
+        }
+    }
+
+   
+
+}

--- a/test/NullDesk.Extensions.Mailer.SendGrid.Tests/Infrastructure/FactoryMailFixture.cs
+++ b/test/NullDesk.Extensions.Mailer.SendGrid.Tests/Infrastructure/FactoryMailFixture.cs
@@ -17,10 +17,10 @@ namespace NullDesk.Extensions.Mailer.SendGrid.Tests.Infrastructure
 
         public FactoryMailFixture()
         {
-
+            
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddDebug(LogLevel.Debug);
-
+            
             var sendGridSettings = new SendGridMailerSettings { ApiKey = "abc" };
 
             var logger = loggerFactory.CreateLogger<SendGridMailer>();

--- a/test/NullDesk.Extensions.Mailer.SendGrid.Tests/Infrastructure/ReusableMailFixture.cs
+++ b/test/NullDesk.Extensions.Mailer.SendGrid.Tests/Infrastructure/ReusableMailFixture.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NullDesk.Extensions.Mailer.Core;
+
+namespace NullDesk.Extensions.Mailer.SendGrid.Tests.Infrastructure
+{
+    public class ReusableMailFixture : IDisposable
+    {
+        public IServiceProvider ServiceProvider { get; set; }
+
+        public ReusableMailFixture()
+        {
+
+            //setup the dependency injection service
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+            services.AddSingleton<IHistoryStore, InMemoryHistoryStore>();
+
+            services.Configure<SendGridMailerSettings>(s => s.ApiKey = "abc");
+
+            services.AddSingleton<SendGridSimpleMailerFake>();
+                
+            services.AddSingleton<ISimpleMailer>(s => s.GetService<SendGridSimpleMailerFake>());
+
+
+            ServiceProvider = services.BuildServiceProvider();
+            var logging = ServiceProvider.GetService<ILoggerFactory>();
+            logging.AddDebug(LogLevel.Debug);
+        }
+
+
+
+        public void Dispose()
+        {
+
+        }
+
+
+    }
+}

--- a/test/NullDesk.Extensions.Mailer.SendGrid.Tests/SendGridParallelMailerTests.cs
+++ b/test/NullDesk.Extensions.Mailer.SendGrid.Tests/SendGridParallelMailerTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using FluentAssertions;
+using NullDesk.Extensions.Mailer.Core;
+using NullDesk.Extensions.Mailer.SendGrid.Tests.Infrastructure;
+using NullDesk.Extensions.Mailer.Tests.Common;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NullDesk.Extensions.Mailer.SendGrid.Tests
+{
+    public class SendGridParallelMailerTests : IClassFixture<ReusableMailFixture>
+    {
+        private ReusableMailFixture Fixture { get; }
+
+        public SendGridParallelMailerTests(ReusableMailFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+
+        [Theory]
+        [Trait("TestType", "Integration")]
+        [ClassData(typeof(StandardMailerTestData))]
+        public void SendMail(string html, string text, string[] attachments)
+        {
+            var mailer = Fixture.ServiceProvider.GetService<ISimpleMailer>();
+            var messages = new List<TestParallelMailMessage>();
+            for (var i = 0; i < 10; i++)
+            {
+                messages.Add(new TestParallelMailMessage
+                {
+                    To = $"noone{i}@toast.com",
+                    ToDisplay = "No One Important",
+                    Subject = $"#{i} - Parallel xunit Test run: no template",
+                    Html = html,
+                    Text = text
+                });
+            }
+            Parallel.ForEach(messages, (mes) =>
+            {
+                var result =
+                   mailer.SendMailAsync(
+                            mes.To,
+                            mes.ToDisplay,
+                            mes.Subject,
+                            mes.Html,
+                            mes.Text,
+                            (IEnumerable<string>)null,
+                            CancellationToken.None
+                        ).Result;
+
+                var m = result.Should().NotBeNull().And.BeOfType<MessageDeliveryItem>().Which;
+                m.IsSuccess.Should().BeTrue();
+                m.MessageData.Should().NotBeNullOrEmpty();
+            });
+        }
+
+    }
+}

--- a/test/NullDesk.Extensions.Mailer.Tests.Common/TestParallelMailMessage.cs
+++ b/test/NullDesk.Extensions.Mailer.Tests.Common/TestParallelMailMessage.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NullDesk.Extensions.Mailer.Tests.Common
+{
+    public class TestParallelMailMessage
+    {
+        public string To { get; set; }
+        public string ToDisplay { get; set; }
+        public string Subject { get; set; }
+        public string Html { get; set; }
+        public string Text { get; set; }
+    }
+}


### PR DESCRIPTION
Ensures mailers are reusable, implement idisposable, and are tested for parallel usage. MailKit performs poorly when re-using mailer instances, so the readme as been updated to recommend not reusing them.