### PR TITLE
closes #31 - adds provider message id to delivery history

### DIFF
--- a/samples/mailer-cli/mailer/Properties/launchSettings.json
+++ b/samples/mailer-cli/mailer/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "mailer": {
+      "commandName": "Project",
+      "commandLineArgs": "send simple"
+    }
+  }
+}

--- a/src/NullDesk.Extensions.Mailer.Core/MailerModel/Mailer.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/MailerModel/Mailer.cs
@@ -156,7 +156,7 @@ namespace NullDesk.Extensions.Mailer.Core
                 var deliveryItem = ((IMailer)this).Deliverables.FirstOrDefault(d => d.Id == id);
                 try
                 {
-                    deliveryItem = await DeliverMessageAsync(deliveryItem, token);
+                    deliveryItem.ProviderMessageId = await DeliverMessageAsync(deliveryItem, token);
                     deliveryItem.IsSuccess = true;
                     deliveryItem.DeliveryProvider = GetType().Name;
                 }
@@ -195,13 +195,14 @@ namespace NullDesk.Extensions.Mailer.Core
         public abstract void Dispose();
 
         /// <summary>
-        ///     When overridden in a derived class, uses the mailer's underlying mail delivery service to send the specified
-        ///     message .
+        /// When overridden in a derived class, uses the mailer's underlying mail delivery service to send the specified
+        /// message and return the service's native message identifier (or null if not applicable).
         /// </summary>
         /// <param name="deliveryItem">The delivery item containing the message you wish to send.</param>
         /// <param name="token">The token.</param>
-        /// <returns>Task&lt;DeliveryItem&gt;.</returns>
-        protected abstract Task<DeliveryItem> DeliverMessageAsync(DeliveryItem deliveryItem,
+        /// <returns>Task&lt;String&gt; a service provider specific message ID.</returns>
+        /// <remarks>The implementor should return a provider specific ID value.</remarks>
+        protected abstract Task<string> DeliverMessageAsync(DeliveryItem deliveryItem,
             CancellationToken token = new CancellationToken());
 
         private void CheckIsDeliverable(MailerMessage message)

--- a/src/NullDesk.Extensions.Mailer.Core/MailerModel/NullMailer.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/MailerModel/NullMailer.cs
@@ -38,11 +38,11 @@ namespace NullDesk.Extensions.Mailer.Core
         /// <param name="deliveryItem">The delivery item containing the message you wish to send.</param>
         /// <param name="token">The token.</param>
         /// <returns>Task&lt;DeliveryItem&gt;.</returns>
-        protected override Task<DeliveryItem> DeliverMessageAsync(DeliveryItem deliveryItem,
+        protected override Task<string> DeliverMessageAsync(DeliveryItem deliveryItem,
             CancellationToken token = new CancellationToken())
         {
             deliveryItem.IsSuccess = true;
-            return Task.FromResult(deliveryItem);
+            return Task.FromResult(Guid.NewGuid().ToString());
         }
     }
 }

--- a/src/NullDesk.Extensions.Mailer.Core/MessageModel/DeliveryItem.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/MessageModel/DeliveryItem.cs
@@ -55,6 +55,16 @@ namespace NullDesk.Extensions.Mailer.Core
         public string DeliveryProvider { get; set; }
 
         /// <summary>
+        /// Gets or sets the provider's identifier for the message.
+        /// </summary>
+        /// <remarks>
+        /// Used to reference the message in the underlying mail system after delivery has been attempted.
+        /// </remarks>
+        /// <value>The provider message identifier.</value>
+        [StringLength(100)]
+        public string ProviderMessageId { get; set; }
+
+        /// <summary>
         ///     Gets or sets the message created date.
         /// </summary>
         /// <value>The message date.</value>

--- a/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/Migrations/20170309223806_v3.0.1.Designer.cs
+++ b/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/Migrations/20170309223806_v3.0.1.Designer.cs
@@ -10,9 +10,10 @@ using NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer;
 namespace NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer.Migrations
 {
     [DbContext(typeof(SqlHistoryContext))]
-    partial class SqlHistoryContextModelSnapshot : ModelSnapshot
+    [Migration("20170309223806_v3.0.1")]
+    partial class v301
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "1.1.1")

--- a/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/Migrations/20170309223806_v3.0.1.cs
+++ b/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/Migrations/20170309223806_v3.0.1.cs
@@ -1,0 +1,27 @@
+﻿// ReSharper disable All
+#pragma warning disable 1591
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer.Migrations
+{
+    public partial class v301 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProviderMessageId",
+                table: "MessageHistory",
+                maxLength: 100,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProviderMessageId",
+                table: "MessageHistory");
+        }
+    }
+}

--- a/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer.csproj
+++ b/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer.csproj
@@ -23,6 +23,7 @@
         <ProjectReference Include="..\NullDesk.Extensions.Mailer.History.EntityFramework\NullDesk.Extensions.Mailer.History.EntityFramework.csproj" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.1" />

--- a/src/NullDesk.Extensions.Mailer.SendGrid/MailerModel/SendGridMailer.cs
+++ b/src/NullDesk.Extensions.Mailer.SendGrid/MailerModel/SendGridMailer.cs
@@ -36,7 +36,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid
             : base(settings.Value, logger, historyStore)
         {
             MailClient = client;
-           
+
         }
 
         /// <summary>
@@ -58,16 +58,14 @@ namespace NullDesk.Extensions.Mailer.SendGrid
         /// </summary>
         /// <value>The mail client.</value>
         public SendGridClient MailClient { get; set; }
-       
 
         /// <summary>
-        ///     deliver a message as an asynchronous operation.
+        /// Delivers the message asynchronous.
         /// </summary>
-        /// <param name="deliveryItem">The delivery item containing the message you wish to send.</param>
+        /// <param name="deliveryItem">The delivery item.</param>
         /// <param name="token">The token.</param>
-        /// <returns>Task&lt;DeliveryItem&gt;.</returns>
-        protected override async Task<DeliveryItem> DeliverMessageAsync(DeliveryItem deliveryItem,
-            CancellationToken token = default(CancellationToken))
+        /// <returns>System.Threading.Tasks.Task&lt;System.String&gt;.</returns>
+        protected override async Task<string> DeliverMessageAsync(DeliveryItem deliveryItem, CancellationToken token = default(CancellationToken))
         {
             var sgFrom = new EmailAddress(deliveryItem.FromEmailAddress, deliveryItem.FromDisplayName);
             var sgTo = new EmailAddress(deliveryItem.ToEmailAddress, deliveryItem.ToDisplayName);
@@ -92,7 +90,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid
             }
             else
             {
-                sgMessage.SetTemplateId(((TemplateBody) deliveryItem.Body).TemplateName);
+                sgMessage.SetTemplateId(((TemplateBody)deliveryItem.Body).TemplateName);
             }
 
             await AddAttachmentStreamsAsync(sgMessage, deliveryItem.Attachments, token);
@@ -100,17 +98,17 @@ namespace NullDesk.Extensions.Mailer.SendGrid
             var sgResponse = await SendToApiAsync(sgMessage, token);
 
 
-            var isSuccess = sgResponse.StatusCode == HttpStatusCode.Accepted ||
-                            Settings.IsSandboxMode && sgResponse.StatusCode == HttpStatusCode.OK;
+
+            var isSuccess = sgResponse?.StatusCode == HttpStatusCode.Accepted ||
+                            Settings.IsSandboxMode && sgResponse?.StatusCode == HttpStatusCode.OK;
 
             if (isSuccess)
             {
-                //TODO: Enhance delivery item to store arbitrary data from mail service provider
-                return deliveryItem;
+                return sgResponse?.Headers?.GetValues("X-Message-Id").FirstOrDefault(); ;
             }
 
             throw new Exception(
-                $"Unable to delivery message; SendGrid response HTTP StatusCode is: {sgResponse.StatusCode}");
+                $"Unable to delivery message; SendGrid response HTTP StatusCode is: {sgResponse?.StatusCode}");
         }
 
         /// <summary>


### PR DESCRIPTION
Alters mailer deliver message to return a string for the provider's message id. Adds migration for new property in delivery item.