### PR TITLE
Closes #48 Adds resend tests back as unit tests

### DIFF
--- a/test/NullDesk.Extensions.Mailer.MailKit.Tests/MailKitMessageHistoryTests.cs
+++ b/test/NullDesk.Extensions.Mailer.MailKit.Tests/MailKitMessageHistoryTests.cs
@@ -26,7 +26,7 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests
 
 
         [Theory]
-        [Trait("TestType", "LocalOnly")]
+        [Trait("TestType", "Unit")]
         [ClassData(typeof(StandardMailerTestData))]
         public async Task MailKit__History_SerializedAttachments_ReSendMail(string html, string text,
             string[] attachments)
@@ -66,7 +66,7 @@ namespace NullDesk.Extensions.Mailer.MailKit.Tests
         }
 
         [Theory]
-        [Trait("TestType", "LocalOnly")]
+        [Trait("TestType", "Unit")]
         [ClassData(typeof(StandardMailerTestData))]
         public async Task MailKit_History_NoSerializedAttachments_ReSendMail(string html, string text,
             string[] attachments)

--- a/test/NullDesk.Extensions.Mailer.SendGrid.Tests/SendGridMessageHistoryTests.cs
+++ b/test/NullDesk.Extensions.Mailer.SendGrid.Tests/SendGridMessageHistoryTests.cs
@@ -25,7 +25,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid.Tests
 
 
         [Theory]
-        [Trait("TestType", "LocalOnly")]
+        [Trait("TestType", "Unit")]
         [ClassData(typeof(StandardMailerTestData))]
         public async Task SendGrid_History_SerializedAttachments_ReSendMail(string html, string text,
             string[] attachments)
@@ -64,7 +64,7 @@ namespace NullDesk.Extensions.Mailer.SendGrid.Tests
         }
 
         [Theory]
-        [Trait("TestType", "LocalOnly")]
+        [Trait("TestType", "Unit")]
         [ClassData(typeof(StandardMailerTestData))]
         public async Task SendGrid_History_NoSerializedAttachments_ReSendMail(string html, string text,
             string[] attachments)


### PR DESCRIPTION
Changes for unrelated issues may have fixed the CI server's ability to run resend tests.