### PR TITLE
Fixes #77 Source app name can be set directly

### DIFF
--- a/src/NullDesk.Extensions.Mailer.Core/HistoryModel/InMemoryHistoryStore.cs
+++ b/src/NullDesk.Extensions.Mailer.Core/HistoryModel/InMemoryHistoryStore.cs
@@ -52,7 +52,11 @@ namespace NullDesk.Extensions.Mailer.Core
                     item.Attachments = item.Attachments.Select(i => new KeyValuePair<string, Stream>(i.Key, null))
                         .ToDictionary(k => k.Key, k => k.Value);
                 }
-                item.SourceApplicationName = Settings.SourceApplicationName;
+                if (string.IsNullOrEmpty(item.SourceApplicationName) &&
+                    !string.IsNullOrEmpty(Settings.SourceApplicationName))
+                {
+                    item.SourceApplicationName = Settings.SourceApplicationName;
+                }
 
                 Items.Add(JsonConvert.SerializeObject(item));
                 id = item.Id;

--- a/src/NullDesk.Extensions.Mailer.Core/NullDesk.Extensions.Mailer.Core.csproj
+++ b/src/NullDesk.Extensions.Mailer.Core/NullDesk.Extensions.Mailer.Core.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extensions base classes and abstractions for email messaging services</Description>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.0.2</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer.csproj
+++ b/src/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer/NullDesk.Extensions.Mailer.History.EntityFramework.SqlServer.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extension for SQL Server email messsage and delivery history storage using EntityFramework Core</Description>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.0.2</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/NullDesk.Extensions.Mailer.History.EntityFramework/EntityHistoryStore.cs
+++ b/src/NullDesk.Extensions.Mailer.History.EntityFramework/EntityHistoryStore.cs
@@ -27,7 +27,7 @@ namespace NullDesk.Extensions.Mailer.History.EntityFramework
             ILogger<EntityHistoryStore<TContext>> logger = null)
         {
             Settings = settings;
-            Logger = (ILogger) logger ?? NullLogger.Instance;
+            Logger = (ILogger)logger ?? NullLogger.Instance;
         }
 
         /// <summary>
@@ -40,7 +40,11 @@ namespace NullDesk.Extensions.Mailer.History.EntityFramework
         {
             if (Settings.IsEnabled)
             {
-                item.SourceApplicationName = Settings.SourceApplicationName;
+                if (string.IsNullOrEmpty(item.SourceApplicationName) &&
+                    !string.IsNullOrEmpty(Settings.SourceApplicationName))
+                {
+                    item.SourceApplicationName = Settings.SourceApplicationName;
+                }
                 using (var context = GetContext())
                 {
                     context.MessageHistory.Add(item.ToEntityHistoryDeliveryItem(Settings.StoreAttachmentContents));
@@ -64,7 +68,7 @@ namespace NullDesk.Extensions.Mailer.History.EntityFramework
             {
                 using (var context = GetContext())
                 {
-                    return (await context.FindAsync<EntityHistoryDeliveryItem>(new object[] {id}, token))
+                    return (await context.FindAsync<EntityHistoryDeliveryItem>(new object[] { id }, token))
                         ?.ToDeliveryItem();
                 }
             }
@@ -173,12 +177,12 @@ namespace NullDesk.Extensions.Mailer.History.EntityFramework
         /// <returns>HistoryContext.</returns>
         public HistoryContext GetHistoryContext()
         {
-            return (TContext) Activator.CreateInstance(typeof(TContext), Settings.DbOptions);
+            return (TContext)Activator.CreateInstance(typeof(TContext), Settings.DbOptions);
         }
 
         private TContext GetContext()
         {
-            var context = (TContext) Activator.CreateInstance(typeof(TContext), Settings.DbOptions);
+            var context = (TContext)Activator.CreateInstance(typeof(TContext), Settings.DbOptions);
             if (Settings.AutoInitializeDatabase && !_isInitialized)
             {
                 Logger.LogInformation("Beginning history database auto-initialization");

--- a/src/NullDesk.Extensions.Mailer.History.EntityFramework/NullDesk.Extensions.Mailer.History.EntityFramework.csproj
+++ b/src/NullDesk.Extensions.Mailer.History.EntityFramework/NullDesk.Extensions.Mailer.History.EntityFramework.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extensions base implementation of messsage and delivery history storage with EntityFramework Core.</Description>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.0.2</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/NullDesk.Extensions.Mailer.MailKit/NullDesk.Extensions.Mailer.MailKit.csproj
+++ b/src/NullDesk.Extensions.Mailer.MailKit/NullDesk.Extensions.Mailer.MailKit.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extensions for SMTP Email messaging using MailKit</Description>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.0.2</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/NullDesk.Extensions.Mailer.SendGrid/NullDesk.Extensions.Mailer.SendGrid.csproj
+++ b/src/NullDesk.Extensions.Mailer.SendGrid/NullDesk.Extensions.Mailer.SendGrid.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>NullDesk Mailer Extensions for Email messaging using SendGrid API services</Description>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.0.2</VersionPrefix>
     <Authors>Stephen M. Redd</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
- SourceApplicationName will only be set from settings when deliveryitem doesn't supply an explicit value
- Version degraded to 4.0.2 in prep for new hotfix